### PR TITLE
Add a bunch more tweaks to the parallel test compilation

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -159,6 +159,7 @@ go_test_dir() {
 # Compile phase run by parallel in test-unit. No support for coverpkg
 go_compile_test_dir() {
 	dir=$1
+	out_file="$DEST/precompiled/$dir.test"
 	testcover=()
 	if [ "$HAVE_GO_TEST_COVER" ]; then
 		# if our current go install has -cover, we want to use it :)
@@ -167,12 +168,16 @@ go_compile_test_dir() {
 		coverprofile="$DEST/coverprofiles/${coverprofile//\//-}"
 		testcover=( -cover -coverprofile "$coverprofile" ) # missing $coverpkg
 	fi
-	(
+	if [ "$BUILDFLAGS_FILE" ]; then
 		readarray -t BUILDFLAGS < "$BUILDFLAGS_FILE"
+	fi
+	(
 		cd "$dir"
 		go test "${testcover[@]}" -ldflags "$LDFLAGS" "${BUILDFLAGS[@]}" $TESTFLAGS -c
-		echo "$dir"
 	)
+	mkdir -p "$(dirname "$out_file")"
+	mv "$dir/$(basename "$dir").test" "$out_file"
+	echo "Precompiled: github.com/dotcloud/docker${dir#.}"
 }
 
 # This helper function walks the current directory looking for directories

--- a/hack/make/test-unit
+++ b/hack/make/test-unit
@@ -2,11 +2,11 @@
 set -e
 
 DEST=$1
+: ${PARALLEL_JOBS:=$(nproc)}
 
 RED=$'\033[31m'
 GREEN=$'\033[32m'
 TEXTRESET=$'\033[0m' # reset the foreground colour
-: ${PARALLEL_JOBS:=0}
 
 # Run Docker's test suite, including sub-packages, and store their output as a bundle
 # If $TESTFLAGS is set in the environment, it is passed as extra arguments to 'go test'.
@@ -23,10 +23,10 @@ bundle_test_unit() {
 			TESTDIRS=$(find_dirs '*_test.go')
 		fi
 
-		(
+		if command -v parallel &> /dev/null; then (
 			# accomodate parallel to be able to access variables
-			export SHELL=/bin/bash 
-			export HOME=/tmp
+			export SHELL="$BASH"
+			export HOME="$(mktemp -d)"
 			mkdir -p "$HOME/.parallel"
 			touch "$HOME/.parallel/ignored_vars"
 			export -f go_compile_test_dir
@@ -38,8 +38,15 @@ bundle_test_unit() {
 			export BUILDFLAGS_FILE="$HOME/buildflags_file"
 			( IFS=$'\n'; echo "${BUILDFLAGS[*]}" ) > "$BUILDFLAGS_FILE"
 
-			echo "$TESTDIRS" | parallel --jobs "$PARALLEL_JOBS" --env _ go_compile_test_dir | go_run_test_dir
-		)
+			echo "$TESTDIRS" | parallel --jobs "$PARALLEL_JOBS" --env _ go_compile_test_dir
+			rm -rf "$HOME"
+		) else
+			# aww, no "parallel" available - fall back to boring
+			for test_dir in $TESTDIRS; do
+				go_compile_test_dir "$test_dir"
+			done
+		fi
+		echo "$TESTDIRS" | go_run_test_dir
 	}
 }
 
@@ -48,16 +55,13 @@ go_run_test_dir() {
 	while read dir; do
 		echo
 		echo '+ go test' $TESTFLAGS "github.com/dotcloud/docker${dir#.}"
-		pushd "$dir" > /dev/null
-		t=$(basename "$dir").test
-		if ! ./$t; then
+		precompiled="$DEST/precompiled/$dir.test"
+		if ! "$precompiled"; then
 			TESTS_FAILED+=("$dir")
 			echo
 			echo "${RED}Tests failed: $dir${TEXTRESET}"
 			sleep 1 # give it a second, so observers watching can take note
 		fi
-		rm ./$t || true
-		popd > /dev/null
 	done
 
 	echo


### PR DESCRIPTION
- put all the precompiled test binaries in $DEST so they show up in bundles and can be re-run individually afterwards
- support cases where parallel is not installed (when using dyntest-unit, for example, this is much more common, since it's designed to be run outside the Dockerfile)
- use "mktemp -d" instead of "/tmp" directly for our temporary parallel HOME
- update the default PARALLEL_JOBS to be the value of "nproc" instead of 0, since "0 means as many as possible" (see https://www.gnu.org/software/parallel/man.html#jobs_n)
